### PR TITLE
Json, Yaml, ComposerVersionConstraint, ComposerDependencyBlacklist, EditorConfig, ConventionalCommit fixers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM php:7.4
 USER root
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git zip unzip libzip4 libzip-dev ssh && \
+    apt-get install -y --no-install-recommends git zip unzip libzip4 libzip-dev ssh libyaml-dev && \
     curl -sSL https://getcomposer.org/composer.phar -o /usr/bin/composer && \
     chmod +x /usr/bin/composer && \
     composer selfupdate && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /app
+
+RUN pecl install yaml-2.1.0 && docker-php-ext-enable yaml
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.4
 USER root
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git zip unzip libzip4 libzip-dev ssh libyaml-dev && \
+    apt-get install -y --no-install-recommends git zip unzip libzip4 libzip-dev ssh libyaml-dev nodejs npm && \
     curl -sSL https://getcomposer.org/composer.phar -o /usr/bin/composer && \
     chmod +x /usr/bin/composer && \
     composer selfupdate && \

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "symfony/http-client": "5.0.*",
     "symfony/twig-bundle": "5.0.*",
     "symfony/yaml": "5.0.*",
-    "ext-json": "*",
-    "ext-yaml": "*"
+    "ext-json": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "symfony/http-client": "5.0.*",
     "symfony/twig-bundle": "5.0.*",
     "symfony/yaml": "5.0.*",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-yaml": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,14 +24,15 @@ services:
 
     Linkorb\MultiRepo\Factory\MiddlewareFactoryPool:
         calls:
-            - [addToPool, ['githubWorkflows', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createGithubActionsFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
+            - [addToPool, ['githubWorkflows', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createGithubActionsFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
             - [addToPool, ['qaChecks', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createQaFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
-            - [addToPool, ['circleci', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createCircleCiFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
+            - [addToPool, ['circleci', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createCircleCiFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
             - [addToPool, ['json', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createJsonFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
             - [addToPool, ['yaml', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createYamlFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
             - [addToPool, ['composerVersionConstraint', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createComposerJsonVersionConstraint'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
             - [addToPool, ['composerDependencyBlacklist', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createComposerJsonDependencyBlacklist'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
-            - [addToPool, ['editorConfig', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createEditorConfig'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
+            - [addToPool, ['editorConfig', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createEditorConfig'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper'] }]]
+            - [addToPool, ['conventionalCommit', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createConventionalCommit'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper', '@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
 
     Linkorb\MultiRepo\Handler\RepositoryHandler:
         arguments:
@@ -44,3 +45,7 @@ services:
     Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper:
         arguments:
             $templatesDir: '%kernel.project_dir%/templates/dockerfile'
+
+    Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper:
+        arguments:
+            $twig: '@twig'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,6 +29,7 @@ services:
             - [addToPool, ['circleci', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createCircleCiFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
             - [addToPool, ['json', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createJsonFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
             - [addToPool, ['yaml', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createYamlFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
+            - [addToPool, ['composerJsonVersionConstraint', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createComposerJsonVersionConstraint'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
 
     Linkorb\MultiRepo\Handler\RepositoryHandler:
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -31,6 +31,7 @@ services:
             - [addToPool, ['yaml', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createYamlFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
             - [addToPool, ['composerVersionConstraint', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createComposerJsonVersionConstraint'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
             - [addToPool, ['composerDependencyBlacklist', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createComposerJsonDependencyBlacklist'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
+            - [addToPool, ['editorConfig', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createEditorConfig'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
 
     Linkorb\MultiRepo\Handler\RepositoryHandler:
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -27,6 +27,7 @@ services:
             - [addToPool, ['githubWorkflows', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createGithubActionsFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
             - [addToPool, ['qaChecks', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createQaFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
             - [addToPool, ['circleci', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createCircleCiFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
+            - [addToPool, ['json', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createJsonFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
 
     Linkorb\MultiRepo\Handler\RepositoryHandler:
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,6 +28,7 @@ services:
             - [addToPool, ['qaChecks', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createQaFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
             - [addToPool, ['circleci', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createCircleCiFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
             - [addToPool, ['json', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createJsonFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
+            - [addToPool, ['yaml', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createYamlFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
 
     Linkorb\MultiRepo\Handler\RepositoryHandler:
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,7 +29,8 @@ services:
             - [addToPool, ['circleci', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createCircleCiFactory'], arguments: ['@Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper', '@twig', '@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper'] }]]
             - [addToPool, ['json', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createJsonFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
             - [addToPool, ['yaml', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createYamlFactory'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface'] }]]
-            - [addToPool, ['composerJsonVersionConstraint', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createComposerJsonVersionConstraint'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
+            - [addToPool, ['composerVersionConstraint', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createComposerJsonVersionConstraint'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
+            - [addToPool, ['composerDependencyBlacklist', !service { factory: ['Linkorb\MultiRepo\Factory\MiddlewareFactory', 'createComposerJsonDependencyBlacklist'], arguments: ['@Linkorb\MultiRepo\Services\Io\IoInterface', '@Linkorb\MultiRepo\Services\Helper\ShExecHelper'] }]]
 
     Linkorb\MultiRepo\Handler\RepositoryHandler:
         arguments:

--- a/repos.yaml.dist
+++ b/repos.yaml.dist
@@ -29,3 +29,4 @@ parameters:
               “.github/workflows/staging.yml”: https://raw.github.com/…./staging.yml.twig
           json: ~
           yaml: ~
+          composerJsonVersionConstraint: ~

--- a/repos.yaml.dist
+++ b/repos.yaml.dist
@@ -36,3 +36,6 @@ parameters:
                 abused-package: ~ # do not install package (no replacement)
           editorConfig:
             template: https://raw.github.com/linkorb/templates/editorConfig/config.yml.twig
+          conventionalCommit:
+            versionrc: https://raw.github.com/linkorb/templates/conventionalCommit/.versionrc.twig
+            config: https://raw.github.com/linkorb/templates/conventionalCommit/config.js.twig

--- a/repos.yaml.dist
+++ b/repos.yaml.dist
@@ -34,3 +34,5 @@ parameters:
             replace:
                 package-name: replacement # both options can be passed as composer `replace` args
                 abused-package: ~ # do not install package (no replacement)
+          editorConfig:
+            template: https://raw.github.com/linkorb/templates/editorConfig/config.yml.twig

--- a/repos.yaml.dist
+++ b/repos.yaml.dist
@@ -27,8 +27,14 @@ parameters:
             templates:
               “.github/workflows/production.yml”: https://raw.github.com/…./production.yml.twig
               “.github/workflows/staging.yml”: https://raw.github.com/…./staging.yml.twig
-          json: ~
-          yaml: ~
+          json:
+              indentStyle: space # one of "space|tab"
+              indentSize: 2
+              lineBreaks: LF # one of "CR|LF|CRLF"
+          yaml:
+              indentStyle: space # one of "space|tab"
+              indentSize: 2
+              lineBreaks: LF # one of "CR|LF|CRLF"
           composerVersionConstraint: ~
           composerDependencyBlacklist:
             replace:

--- a/repos.yaml.dist
+++ b/repos.yaml.dist
@@ -27,3 +27,5 @@ parameters:
             templates:
               “.github/workflows/production.yml”: https://raw.github.com/…./production.yml.twig
               “.github/workflows/staging.yml”: https://raw.github.com/…./staging.yml.twig
+          json: ~
+          yaml: ~

--- a/repos.yaml.dist
+++ b/repos.yaml.dist
@@ -31,6 +31,7 @@ parameters:
               indentStyle: space # one of "space|tab"
               indentSize: 2
               lineBreaks: LF # one of "CR|LF|CRLF"
+              inline: 100 # how deep do you want to unfold collections (`-` instead of `[]`)
           yaml:
               indentStyle: space # one of "space|tab"
               indentSize: 2

--- a/repos.yaml.dist
+++ b/repos.yaml.dist
@@ -29,4 +29,8 @@ parameters:
               “.github/workflows/staging.yml”: https://raw.github.com/…./staging.yml.twig
           json: ~
           yaml: ~
-          composerJsonVersionConstraint: ~
+          composerVersionConstraint: ~
+          composerDependencyBlacklist:
+            replace:
+                package-name: replacement # both options can be passed as composer `replace` args
+                abused-package: ~ # do not install package (no replacement)

--- a/src/Factory/MiddlewareFactory.php
+++ b/src/Factory/MiddlewareFactory.php
@@ -5,6 +5,7 @@ namespace Linkorb\MultiRepo\Factory;
 use Linkorb\MultiRepo\Middleware\CircleCiMiddleware;
 use Linkorb\MultiRepo\Middleware\ComposerJsonDependencyBlacklistMiddleware;
 use Linkorb\MultiRepo\Middleware\ComposerJsonVersionConstraintMiddleware;
+use Linkorb\MultiRepo\Middleware\EditorConfigMiddleware;
 use Linkorb\MultiRepo\Middleware\GithubWorkflowMiddleware;
 use Linkorb\MultiRepo\Middleware\JsonMiddleware;
 use Linkorb\MultiRepo\Middleware\QaCheckMiddleware;
@@ -73,6 +74,17 @@ class MiddlewareFactory
     {
         return function () use ($io, $executor): ComposerJsonDependencyBlacklistMiddleware {
             return new ComposerJsonDependencyBlacklistMiddleware($io, $executor);
+        };
+    }
+
+    public static function createEditorConfig(
+        TemplateLocationHelper $helper,
+        Environment $twig,
+        IoInterface $io
+    ): callable
+    {
+        return function () use ($helper, $twig, $io): EditorConfigMiddleware {
+            return new EditorConfigMiddleware($helper, $twig, $io);
         };
     }
 }

--- a/src/Factory/MiddlewareFactory.php
+++ b/src/Factory/MiddlewareFactory.php
@@ -4,6 +4,7 @@ namespace Linkorb\MultiRepo\Factory;
 
 use Linkorb\MultiRepo\Middleware\CircleCiMiddleware;
 use Linkorb\MultiRepo\Middleware\GithubWorkflowMiddleware;
+use Linkorb\MultiRepo\Middleware\JsonMiddleware;
 use Linkorb\MultiRepo\Middleware\QaCheckMiddleware;
 use Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper;
 use Linkorb\MultiRepo\Services\Helper\ShExecHelper;
@@ -41,6 +42,13 @@ class MiddlewareFactory
     {
         return function () use ($helper, $twig, $io, $dockerfileHelper): CircleCiMiddleware {
             return new CircleCiMiddleware($helper, $twig, $io, $dockerfileHelper);
+        };
+    }
+
+    public static function createJsonFactory(IoInterface $io): callable
+    {
+        return function () use ($io): JsonMiddleware {
+            return new JsonMiddleware($io);
         };
     }
 }

--- a/src/Factory/MiddlewareFactory.php
+++ b/src/Factory/MiddlewareFactory.php
@@ -3,6 +3,7 @@
 namespace Linkorb\MultiRepo\Factory;
 
 use Linkorb\MultiRepo\Middleware\CircleCiMiddleware;
+use Linkorb\MultiRepo\Middleware\ComposerJsonVersionConstraintMiddleware;
 use Linkorb\MultiRepo\Middleware\GithubWorkflowMiddleware;
 use Linkorb\MultiRepo\Middleware\JsonMiddleware;
 use Linkorb\MultiRepo\Middleware\QaCheckMiddleware;
@@ -57,6 +58,13 @@ class MiddlewareFactory
     {
         return function () use ($io): YamlMiddleware {
             return new YamlMiddleware($io);
+        };
+    }
+
+    public static function createComposerJsonVersionConstraint(IoInterface $io, ShExecHelper $executor): callable
+    {
+        return function () use ($io, $executor): ComposerJsonVersionConstraintMiddleware {
+            return new ComposerJsonVersionConstraintMiddleware($io, $executor);
         };
     }
 }

--- a/src/Factory/MiddlewareFactory.php
+++ b/src/Factory/MiddlewareFactory.php
@@ -6,6 +6,7 @@ use Linkorb\MultiRepo\Middleware\CircleCiMiddleware;
 use Linkorb\MultiRepo\Middleware\GithubWorkflowMiddleware;
 use Linkorb\MultiRepo\Middleware\JsonMiddleware;
 use Linkorb\MultiRepo\Middleware\QaCheckMiddleware;
+use Linkorb\MultiRepo\Middleware\YamlMiddleware;
 use Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper;
 use Linkorb\MultiRepo\Services\Helper\ShExecHelper;
 use Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper;
@@ -49,6 +50,13 @@ class MiddlewareFactory
     {
         return function () use ($io): JsonMiddleware {
             return new JsonMiddleware($io);
+        };
+    }
+
+    public static function createYamlFactory(IoInterface $io): callable
+    {
+        return function () use ($io): YamlMiddleware {
+            return new YamlMiddleware($io);
         };
     }
 }

--- a/src/Factory/MiddlewareFactory.php
+++ b/src/Factory/MiddlewareFactory.php
@@ -3,6 +3,7 @@
 namespace Linkorb\MultiRepo\Factory;
 
 use Linkorb\MultiRepo\Middleware\CircleCiMiddleware;
+use Linkorb\MultiRepo\Middleware\ComposerJsonDependencyBlacklistMiddleware;
 use Linkorb\MultiRepo\Middleware\ComposerJsonVersionConstraintMiddleware;
 use Linkorb\MultiRepo\Middleware\GithubWorkflowMiddleware;
 use Linkorb\MultiRepo\Middleware\JsonMiddleware;
@@ -65,6 +66,13 @@ class MiddlewareFactory
     {
         return function () use ($io, $executor): ComposerJsonVersionConstraintMiddleware {
             return new ComposerJsonVersionConstraintMiddleware($io, $executor);
+        };
+    }
+
+    public static function createComposerJsonDependencyBlacklist(IoInterface $io, ShExecHelper $executor): callable
+    {
+        return function () use ($io, $executor): ComposerJsonDependencyBlacklistMiddleware {
+            return new ComposerJsonDependencyBlacklistMiddleware($io, $executor);
         };
     }
 }

--- a/src/Factory/MiddlewareFactory.php
+++ b/src/Factory/MiddlewareFactory.php
@@ -5,6 +5,7 @@ namespace Linkorb\MultiRepo\Factory;
 use Linkorb\MultiRepo\Middleware\CircleCiMiddleware;
 use Linkorb\MultiRepo\Middleware\ComposerJsonDependencyBlacklistMiddleware;
 use Linkorb\MultiRepo\Middleware\ComposerJsonVersionConstraintMiddleware;
+use Linkorb\MultiRepo\Middleware\ConventionalCommitMiddleware;
 use Linkorb\MultiRepo\Middleware\EditorConfigMiddleware;
 use Linkorb\MultiRepo\Middleware\GithubWorkflowMiddleware;
 use Linkorb\MultiRepo\Middleware\JsonMiddleware;
@@ -14,7 +15,6 @@ use Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper;
 use Linkorb\MultiRepo\Services\Helper\ShExecHelper;
 use Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper;
 use Linkorb\MultiRepo\Services\Io\IoInterface;
-use Twig\Environment;
 
 class MiddlewareFactory
 {
@@ -27,25 +27,21 @@ class MiddlewareFactory
 
     public static function createGithubActionsFactory(
         TemplateLocationHelper $helper,
-        Environment $twig,
-        IoInterface $io,
         DockerfileInitHelper $dockerfileHelper
     ): callable
     {
-        return function () use ($helper, $twig, $io, $dockerfileHelper): GithubWorkflowMiddleware {
-            return new GithubWorkflowMiddleware($helper, $twig, $io, $dockerfileHelper);
+        return function () use ($helper, $dockerfileHelper): GithubWorkflowMiddleware {
+            return new GithubWorkflowMiddleware($helper, $dockerfileHelper);
         };
     }
 
     public static function createCircleCiFactory(
         TemplateLocationHelper $helper,
-        Environment $twig,
-        IoInterface $io,
         DockerfileInitHelper $dockerfileHelper
     ): callable
     {
-        return function () use ($helper, $twig, $io, $dockerfileHelper): CircleCiMiddleware {
-            return new CircleCiMiddleware($helper, $twig, $io, $dockerfileHelper);
+        return function () use ($helper, $dockerfileHelper): CircleCiMiddleware {
+            return new CircleCiMiddleware($helper, $dockerfileHelper);
         };
     }
 
@@ -77,14 +73,21 @@ class MiddlewareFactory
         };
     }
 
-    public static function createEditorConfig(
+    public static function createEditorConfig(TemplateLocationHelper $helper): callable
+    {
+        return function () use ($helper): EditorConfigMiddleware {
+            return new EditorConfigMiddleware($helper);
+        };
+    }
+
+    public static function createConventionalCommit(
         TemplateLocationHelper $helper,
-        Environment $twig,
+        ShExecHelper $executor,
         IoInterface $io
     ): callable
     {
-        return function () use ($helper, $twig, $io): EditorConfigMiddleware {
-            return new EditorConfigMiddleware($helper, $twig, $io);
+        return function () use ($helper, $executor, $io): ConventionalCommitMiddleware {
+            return new ConventionalCommitMiddleware($helper, $executor, $io);
         };
     }
 }

--- a/src/Middleware/CircleCiMiddleware.php
+++ b/src/Middleware/CircleCiMiddleware.php
@@ -5,29 +5,19 @@ namespace Linkorb\MultiRepo\Middleware;
 use Linkorb\MultiRepo\Dto\FixerInputDto;
 use Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper;
 use Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper;
-use Linkorb\MultiRepo\Services\Io\IoInterface;
-use Twig\Environment;
 
 class CircleCiMiddleware implements MiddlewareInterface
 {
     private TemplateLocationHelper $templateHelper;
 
-    private Environment $twig;
-
-    private IoInterface $io;
-
     private DockerfileInitHelper $dockerfileHelper;
 
     public function __construct(
         TemplateLocationHelper $templateHelper,
-        Environment $twig,
-        IoInterface $io,
         DockerfileInitHelper $dockerfileHelper
     )
     {
         $this->templateHelper = $templateHelper;
-        $this->twig = $twig;
-        $this->io = $io;
         $this->dockerfileHelper = $dockerfileHelper;
     }
 
@@ -35,19 +25,11 @@ class CircleCiMiddleware implements MiddlewareInterface
     {
         $dockerfileName = $this->dockerfileHelper->initDockerfile($input->getRepositoryPath());
 
-        if ($input->getFixerData()['template']
-            && !file_exists(implode(DIRECTORY_SEPARATOR, [$input->getRepositoryPath(), '.circleci', 'config.yml']))
-        ) {
-            $this->io->write(
-                implode(DIRECTORY_SEPARATOR, [$input->getRepositoryPath(), '.circleci']),
-                'config.yml',
-                $this->twig
-                    ->createTemplate($this->templateHelper->getTemplate($input->getFixerData()['template']))
-                    ->render(
-                        ['dockerfile_name' => $dockerfileName]
-                    )
-            );
-        }
+        $this->templateHelper->putIfMissingFromLocation(
+            $input->getFixerData()['template'],
+            [$input->getRepositoryPath(), '.circleci', 'config.yml'],
+            ['dockerfile_name' => $dockerfileName]
+        );
 
         $next();
     }

--- a/src/Middleware/ComposerJsonDependencyBlacklistMiddleware.php
+++ b/src/Middleware/ComposerJsonDependencyBlacklistMiddleware.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Linkorb\MultiRepo\Middleware;
+
+use Exception;
+use Linkorb\MultiRepo\Dto\FixerInputDto;
+use Linkorb\MultiRepo\Services\Helper\ShExecHelper;
+use Linkorb\MultiRepo\Services\Io\IoInterface;
+
+class ComposerJsonDependencyBlacklistMiddleware implements MiddlewareInterface
+{
+    private IoInterface $io;
+
+    private ShExecHelper $executor;
+
+    public function __construct(IoInterface $io, ShExecHelper $executor)
+    {
+        $this->io = $io;
+        $this->executor = $executor;
+    }
+
+    public function __invoke(FixerInputDto $input, callable $next): void
+    {
+        $composerJson = json_decode(
+            $this->io->read($input->getRepositoryPath() . DIRECTORY_SEPARATOR . 'composer.json'),
+            true
+        );
+
+        $doComposerUpdate = false;
+        foreach ($input->getFixerData()['replace'] as $replacedPackage => $replacementPackage) {
+            if (isset($composerJson['replace'][$replacedPackage])) {
+                continue;
+            }
+
+            $composerJson['replace'][$replacedPackage] = $replacementPackage ?? '*';
+            $doComposerUpdate = true;
+        }
+
+        if ($doComposerUpdate) {
+            $this->io->write(
+                $input->getRepositoryPath(),
+                'composer.json',
+                json_encode($composerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+            );
+
+            list($code) = $this->executor->exec('composer update', $input->getRepositoryPath());
+
+            if ($code !== 0) {
+                throw new Exception('Composer dependency blacklist composer update failed with code: ' . $code);
+            }
+        }
+
+        $next();
+    }
+}

--- a/src/Middleware/ComposerJsonVersionConstraintMiddleware.php
+++ b/src/Middleware/ComposerJsonVersionConstraintMiddleware.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Linkorb\MultiRepo\Middleware;
+
+use Exception;
+use Linkorb\MultiRepo\Dto\FixerInputDto;
+use Linkorb\MultiRepo\Services\Helper\ShExecHelper;
+use Linkorb\MultiRepo\Services\Io\IoInterface;
+
+class ComposerJsonVersionConstraintMiddleware implements MiddlewareInterface
+{
+    private IoInterface $io;
+
+    private ShExecHelper $executor;
+
+    public function __construct(IoInterface $io, ShExecHelper $executor)
+    {
+        $this->io = $io;
+        $this->executor = $executor;
+    }
+
+    public function __invoke(FixerInputDto $input, callable $next): void
+    {
+        $composerJson = json_decode(
+            $this->io->read($input->getRepositoryPath() . DIRECTORY_SEPARATOR . 'composer.json'),
+            true
+        );
+
+        if ($alignedRequire = $this->alignPackages($composerJson['require'])) {
+            $composerJson['require']= array_replace($composerJson['require'], $alignedRequire);
+        }
+
+        if ($alignedRequireDev = $this->alignPackages($composerJson['require-dev'])) {
+            $composerJson['require-dev']= array_replace($composerJson['require-dev'], $alignedRequireDev);
+        }
+
+        if (empty($alignedRequireDev) && empty($alignedRequire)) {
+            $next();
+
+            return;
+        }
+
+        $this->io->write(
+            $input->getRepositoryPath(),
+            'composer.json',
+            json_encode($composerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        list($code) = $this->executor->exec(
+            sprintf(
+                'composer update %s',
+                implode(
+                    ' ',
+                    array_merge(array_keys($alignedRequire), array_keys($alignedRequireDev))
+                )
+            ),
+            $input->getRepositoryPath()
+        );
+
+        if ($code !== 0) {
+            throw new Exception('Composer version constraint composer update failed with code: ' . $code);
+        }
+
+        $next();
+    }
+
+    private function alignPackages(array $require): array
+    {
+        $composerRequire = [];
+        foreach ($require as $packageName => $packageVersion) {
+            $composerRequire = array_merge(
+                $composerRequire,
+                $this->alignPackageVersion($packageName, $packageVersion)
+            );
+        }
+
+        return $composerRequire;
+    }
+
+    /**
+     * @return array[string]string
+     */
+    private function alignPackageVersion(string $packageName, string $packageVersion): array
+    {
+        if (strpos($packageVersion, '~') === 0) {
+            return [$packageName => '^' . substr($packageVersion, 1)];
+        }
+
+        return [];
+    }
+}

--- a/src/Middleware/ConventionalCommitMiddleware.php
+++ b/src/Middleware/ConventionalCommitMiddleware.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Linkorb\MultiRepo\Middleware;
+
+use Exception;
+use Linkorb\MultiRepo\Dto\FixerInputDto;
+use Linkorb\MultiRepo\Services\Helper\ShExecHelper;
+use Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper;
+use Linkorb\MultiRepo\Services\Io\IoInterface;
+
+class ConventionalCommitMiddleware implements MiddlewareInterface
+{
+    private TemplateLocationHelper $templateHelper;
+
+    private ShExecHelper $executor;
+
+    private IoInterface $io;
+
+    public function __construct(TemplateLocationHelper $templateHelper, ShExecHelper $executor, IoInterface $io)
+    {
+        $this->templateHelper = $templateHelper;
+        $this->executor = $executor;
+        $this->io = $io;
+    }
+
+    public function __invoke(FixerInputDto $input, callable $next): void
+    {
+        $this->templateHelper->putIfMissingFromLocation(
+            $input->getFixerData()['versionrc'],
+            [$input->getRepositoryPath(), '.versionrc']
+        );
+
+        $this->templateHelper->putIfMissingFromLocation(
+            $input->getFixerData()['config'],
+            [$input->getRepositoryPath(), 'commitlint.config.js']
+        );
+
+        $this->templateHelper->putIfMissingFromString(
+            $this->generatePackageJson(),
+            [$input->getRepositoryPath(), 'package.json']
+        );
+
+        list($code) = $this->executor->exec(
+            'npm install @commitlint/cli @commitlint/config-conventional husky --save-dev',
+            $input->getRepositoryPath()
+        );
+
+        if ($code !== 0) {
+            throw new Exception('Conventional commit dependencies installation failed with code: ' . $code);
+        }
+
+        $packageJson = json_decode(
+            $this->io->read($input->getRepositoryPath(). DIRECTORY_SEPARATOR . 'package.json'),
+            true
+        );
+
+        if (($packageJson['husky']['hooks']['commit-msg'] ?? null) === null) {
+            $packageJson = array_replace_recursive(
+                $packageJson,
+                [
+                    'husky' => [
+                        'hooks' => [
+                            'commit-msg' => 'commitlint -E HUSKY_GIT_PARAMS',
+                        ],
+                    ],
+                ]
+            );
+        }
+
+        $this->io->write(
+            $input->getRepositoryPath(),
+            'package.json',
+            json_encode($packageJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $next();
+    }
+
+    private function generatePackageJson(): string
+    {
+        return <<<JSON
+{
+  "devDependencies": {
+  },
+  "license": "UNLICENSED",
+  "private": true,
+  "scripts": {
+  },
+  "dependencies": {
+  }
+}
+JSON;
+    }
+}

--- a/src/Middleware/EditorConfigMiddleware.php
+++ b/src/Middleware/EditorConfigMiddleware.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Linkorb\MultiRepo\Middleware;
+
+use Linkorb\MultiRepo\Dto\FixerInputDto;
+use Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper;
+use Linkorb\MultiRepo\Services\Io\IoInterface;
+use Twig\Environment;
+
+class EditorConfigMiddleware implements MiddlewareInterface
+{
+    private TemplateLocationHelper $templateHelper;
+
+    private Environment $twig;
+
+    private IoInterface $io;
+
+    public function __construct(TemplateLocationHelper $templateHelper, Environment $twig, IoInterface $io)
+    {
+        $this->templateHelper = $templateHelper;
+        $this->twig = $twig;
+        $this->io = $io;
+    }
+
+    public function __invoke(FixerInputDto $input, callable $next): void
+    {
+        if ($input->getFixerData()['template']
+            && !file_exists($input->getRepositoryPath() . DIRECTORY_SEPARATOR . '.editorconfig')
+        ) {
+            $this->io->write(
+                $input->getRepositoryPath(),
+                '.editorconfig',
+                $this->twig
+                    ->createTemplate($this->templateHelper->getTemplate($input->getFixerData()['template']))
+                    ->render()
+            );
+        }
+
+        $next();
+    }
+}

--- a/src/Middleware/EditorConfigMiddleware.php
+++ b/src/Middleware/EditorConfigMiddleware.php
@@ -4,37 +4,22 @@ namespace Linkorb\MultiRepo\Middleware;
 
 use Linkorb\MultiRepo\Dto\FixerInputDto;
 use Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper;
-use Linkorb\MultiRepo\Services\Io\IoInterface;
-use Twig\Environment;
 
 class EditorConfigMiddleware implements MiddlewareInterface
 {
     private TemplateLocationHelper $templateHelper;
 
-    private Environment $twig;
-
-    private IoInterface $io;
-
-    public function __construct(TemplateLocationHelper $templateHelper, Environment $twig, IoInterface $io)
+    public function __construct(TemplateLocationHelper $templateHelper)
     {
         $this->templateHelper = $templateHelper;
-        $this->twig = $twig;
-        $this->io = $io;
     }
 
     public function __invoke(FixerInputDto $input, callable $next): void
     {
-        if ($input->getFixerData()['template']
-            && !file_exists($input->getRepositoryPath() . DIRECTORY_SEPARATOR . '.editorconfig')
-        ) {
-            $this->io->write(
-                $input->getRepositoryPath(),
-                '.editorconfig',
-                $this->twig
-                    ->createTemplate($this->templateHelper->getTemplate($input->getFixerData()['template']))
-                    ->render()
-            );
-        }
+        $this->templateHelper->putIfMissingFromLocation(
+            $input->getFixerData()['template'],
+            [$input->getRepositoryPath(), '.editorconfig']
+        );
 
         $next();
     }

--- a/src/Middleware/GithubWorkflowMiddleware.php
+++ b/src/Middleware/GithubWorkflowMiddleware.php
@@ -5,29 +5,16 @@ namespace Linkorb\MultiRepo\Middleware;
 use Linkorb\MultiRepo\Dto\FixerInputDto;
 use Linkorb\MultiRepo\Services\Helper\DockerfileInitHelper;
 use Linkorb\MultiRepo\Services\Helper\TemplateLocationHelper;
-use Linkorb\MultiRepo\Services\Io\IoInterface;
-use Twig\Environment;
 
 class GithubWorkflowMiddleware implements MiddlewareInterface
 {
     private TemplateLocationHelper $templateHelper;
 
-    private Environment $twig;
-
-    private IoInterface $io;
-
     private DockerfileInitHelper $dockerfileHelper;
 
-    public function __construct(
-        TemplateLocationHelper $templateHelper,
-        Environment $twig,
-        IoInterface $io,
-        DockerfileInitHelper $dockerfileHelper
-    )
+    public function __construct(TemplateLocationHelper $templateHelper, DockerfileInitHelper $dockerfileHelper)
     {
         $this->templateHelper = $templateHelper;
-        $this->twig = $twig;
-        $this->io = $io;
         $this->dockerfileHelper = $dockerfileHelper;
     }
 
@@ -36,35 +23,17 @@ class GithubWorkflowMiddleware implements MiddlewareInterface
         $templates = $input->getFixerData()['templates'];
         $dockerfileName = $this->dockerfileHelper->initDockerfile($input->getRepositoryPath());
 
-        if ($templates['.github/workflows/staging.yml']
-            && !file_exists(
-                implode(DIRECTORY_SEPARATOR, [$input->getRepositoryPath(), '.github', 'workflows', 'staging.yml'])
-            )
-        ) {
-            $this->io->write(
-                implode(DIRECTORY_SEPARATOR, [$input->getRepositoryPath(), '.github', 'workflows']),
-                'staging.yml',
-                $this->twig
-                    ->createTemplate($this->templateHelper->getTemplate($templates['.github/workflows/staging.yml']))
-                    ->render(['dockerfile_name' => $dockerfileName])
-            );
-        }
+        $this->templateHelper->putIfMissingFromLocation(
+            $templates['.github/workflows/staging.yml'],
+            [$input->getRepositoryPath(), '.github', 'workflows', 'staging.yml'],
+            ['dockerfile_name' => $dockerfileName]
+        );
 
-        if ($templates['.github/workflows/production.yml']
-            && !file_exists(
-                implode(DIRECTORY_SEPARATOR, [$input->getRepositoryPath(), '.github', 'workflows', 'production.yml'])
-            )
-        ) {
-            $this->io->write(
-                implode(DIRECTORY_SEPARATOR, [$input->getRepositoryPath(), '.github', 'workflows']),
-                'production.yml',
-                $this->twig
-                    ->createTemplate(
-                        $this->templateHelper->getTemplate($templates['.github/workflows/production.yml'])
-                    )
-                    ->render(['dockerfile_name' => $dockerfileName])
-            );
-        }
+        $this->templateHelper->putIfMissingFromLocation(
+            $templates['.github/workflows/production.yml'],
+            [$input->getRepositoryPath(), '.github', 'workflows', 'production.yml'],
+            ['dockerfile_name' => $dockerfileName]
+        );
 
         $next();
     }

--- a/src/Middleware/JsonMiddleware.php
+++ b/src/Middleware/JsonMiddleware.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Linkorb\MultiRepo\Middleware;
+
+use Linkorb\MultiRepo\Dto\FixerInputDto;
+use Linkorb\MultiRepo\Services\Io\IoInterface;
+
+class JsonMiddleware implements MiddlewareInterface
+{
+    private IoInterface $io;
+
+    public function __construct(IoInterface $io)
+    {
+        $this->io = $io;
+    }
+
+    public function __invoke(FixerInputDto $input, callable $next): void
+    {
+        foreach ($this->io->findBy('/^.+\.json$/i', $input->getRepositoryPath()) as $filePath => $fileResult) {
+            if (preg_match('/^.\/vendor./', $filePath)) {
+                // Do not fix dependencies :)
+                continue;
+            }
+
+            $filePathComponents = explode(DIRECTORY_SEPARATOR, $filePath);
+            $filename = array_pop($filePathComponents);
+            $fileDir = implode(DIRECTORY_SEPARATOR, $filePathComponents);
+
+            $this->io->write(
+                $fileDir,
+                $filename,
+                json_encode(
+                    json_decode($this->io->read($filePath)),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+                ) . PHP_EOL
+            );
+        }
+
+        $next();
+    }
+}

--- a/src/Middleware/JsonMiddleware.php
+++ b/src/Middleware/JsonMiddleware.php
@@ -3,10 +3,13 @@
 namespace Linkorb\MultiRepo\Middleware;
 
 use Linkorb\MultiRepo\Dto\FixerInputDto;
+use Linkorb\MultiRepo\Services\Helper\IndentionFormatAwareTrait;
 use Linkorb\MultiRepo\Services\Io\IoInterface;
 
 class JsonMiddleware implements MiddlewareInterface
 {
+    use IndentionFormatAwareTrait;
+
     private IoInterface $io;
 
     public function __construct(IoInterface $io)
@@ -26,14 +29,21 @@ class JsonMiddleware implements MiddlewareInterface
             $filename = array_pop($filePathComponents);
             $fileDir = implode(DIRECTORY_SEPARATOR, $filePathComponents);
 
-            $this->io->write(
-                $fileDir,
-                $filename,
-                json_encode(
+            $content = json_encode(
                     json_decode($this->io->read($filePath)),
                     JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
-                ) . PHP_EOL
+                ) . PHP_EOL;
+
+            $content = $this->fixIndent(
+                $content,
+                4,
+                $input->getFixerData()['indentStyle'] ?? null,
+                $input->getFixerData()['indentSize'] ?? 2
             );
+
+            $content = $this->fixLineBreaks($content, $input->getFixerData()['lineBreaks'] ?? null);
+
+            $this->io->write($fileDir, $filename, $content);
         }
 
         $next();

--- a/src/Middleware/YamlMiddleware.php
+++ b/src/Middleware/YamlMiddleware.php
@@ -3,11 +3,14 @@
 namespace Linkorb\MultiRepo\Middleware;
 
 use Linkorb\MultiRepo\Dto\FixerInputDto;
+use Linkorb\MultiRepo\Services\Helper\IndentionFormatAwareTrait;
 use Linkorb\MultiRepo\Services\Io\IoInterface;
 use Symfony\Component\Yaml\Yaml;
 
 class YamlMiddleware implements MiddlewareInterface
 {
+    use IndentionFormatAwareTrait;
+
     private IoInterface $io;
 
     public function __construct(IoInterface $io)
@@ -17,7 +20,7 @@ class YamlMiddleware implements MiddlewareInterface
 
     public function __invoke(FixerInputDto $input, callable $next): void
     {
-        foreach ($this->io->findBy('/^.+\.(yml|yaml)/i', $input->getRepositoryPath()) as $filePath => $fileResult) {
+        foreach ($this->io->findBy('/^.+\.(yml|yaml)$/i', $input->getRepositoryPath()) as $filePath => $fileResult) {
             if (preg_match('/^.\/vendor./', $filePath)) {
                 // Do not fix dependencies :)
                 continue;
@@ -27,17 +30,24 @@ class YamlMiddleware implements MiddlewareInterface
             $filename = array_pop($filePathComponents);
             $fileDir = implode(DIRECTORY_SEPARATOR, $filePathComponents);
 
-            $this->io->write(
-                $fileDir,
-                $filename,
-                preg_replace(
-                    '/^---\n(.*)\.\.\.$/ms',
-                    '$1',
-                    yaml_emit(
-                        Yaml::parse($this->io->read($filePath))
-                    )
-                ),
+            $content = preg_replace(
+                '/^---\n(.*)\.\.\.$/ms',
+                '$1',
+                yaml_emit(
+                    Yaml::parse($this->io->read($filePath))
+                )
             );
+
+            $content = $this->fixIndent(
+                $content,
+                2,
+                $input->getFixerData()['indentStyle'] ?? null,
+                $input->getFixerData()['indentSize'] ?? 2
+            );
+
+            $content = $this->fixLineBreaks($content, $input->getFixerData()['lineBreaks'] ?? null);
+
+            $this->io->write($fileDir, $filename, $content);
         }
 
         $next();

--- a/src/Middleware/YamlMiddleware.php
+++ b/src/Middleware/YamlMiddleware.php
@@ -30,20 +30,23 @@ class YamlMiddleware implements MiddlewareInterface
             $filename = array_pop($filePathComponents);
             $fileDir = implode(DIRECTORY_SEPARATOR, $filePathComponents);
 
-            $content = preg_replace(
-                '/^---\n(.*)\.\.\.$/ms',
-                '$1',
-                yaml_emit(
-                    Yaml::parse($this->io->read($filePath))
-                )
+            $identSize = $input->getFixerData()['indentSize'] ?? 2;
+
+            $content = Yaml::dump(
+                Yaml::parse($this->io->read($filePath)),
+                100,
+                $identSize,
+                Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_NULL_AS_TILDE | Yaml::DUMP_OBJECT | Yaml::DUMP_OBJECT_AS_MAP
             );
 
-            $content = $this->fixIndent(
-                $content,
-                2,
-                $input->getFixerData()['indentStyle'] ?? null,
-                $input->getFixerData()['indentSize'] ?? 2
-            );
+            if (!in_array($input->getFixerData()['indentStyle'] ?? null, [null, 'space'], true)) {
+                $content = $this->fixIndent(
+                    $content,
+                    $identSize,
+                    $input->getFixerData()['indentStyle'] ?? null,
+                    $identSize
+                );
+            }
 
             $content = $this->fixLineBreaks($content, $input->getFixerData()['lineBreaks'] ?? null);
 

--- a/src/Middleware/YamlMiddleware.php
+++ b/src/Middleware/YamlMiddleware.php
@@ -34,7 +34,7 @@ class YamlMiddleware implements MiddlewareInterface
 
             $content = Yaml::dump(
                 Yaml::parse($this->io->read($filePath)),
-                100,
+                $input->getFixerData()['inline'] ?? 100,
                 $identSize,
                 Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_NULL_AS_TILDE | Yaml::DUMP_OBJECT | Yaml::DUMP_OBJECT_AS_MAP
             );

--- a/src/Middleware/YamlMiddleware.php
+++ b/src/Middleware/YamlMiddleware.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Linkorb\MultiRepo\Middleware;
+
+use Linkorb\MultiRepo\Dto\FixerInputDto;
+use Linkorb\MultiRepo\Services\Io\IoInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class YamlMiddleware implements MiddlewareInterface
+{
+    private IoInterface $io;
+
+    public function __construct(IoInterface $io)
+    {
+        $this->io = $io;
+    }
+
+    public function __invoke(FixerInputDto $input, callable $next): void
+    {
+        foreach ($this->io->findBy('/^.+\.(yml|yaml)/i', $input->getRepositoryPath()) as $filePath => $fileResult) {
+            if (preg_match('/^.\/vendor./', $filePath)) {
+                // Do not fix dependencies :)
+                continue;
+            }
+
+            $filePathComponents = explode(DIRECTORY_SEPARATOR, $filePath);
+            $filename = array_pop($filePathComponents);
+            $fileDir = implode(DIRECTORY_SEPARATOR, $filePathComponents);
+
+            $this->io->write(
+                $fileDir,
+                $filename,
+                preg_replace(
+                    '/^---\n(.*)\.\.\.$/ms',
+                    '$1',
+                    yaml_emit(
+                        Yaml::parse($this->io->read($filePath))
+                    )
+                ),
+            );
+        }
+
+        $next();
+    }
+}

--- a/src/Services/Helper/IndentionFormatAwareTrait.php
+++ b/src/Services/Helper/IndentionFormatAwareTrait.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Linkorb\MultiRepo\Services\Helper;
+
+trait IndentionFormatAwareTrait
+{
+    private function fixIndent(string $content, int $formattedIndent, ?string $indentStyle, int $indentSize): string
+    {
+        $getIndentStyle = function (?string $configValue): string {
+            switch ($configValue ?? 'space') {
+                case 'tab':
+                    return "\t";
+                case 'space':
+                default:
+                    return ' ';
+            }
+        };
+
+        return preg_replace(
+            sprintf('/(^|\G) {%d}/m', $formattedIndent),
+            str_repeat($getIndentStyle($indentStyle), $indentSize),
+            $content
+        );
+    }
+
+    private function fixLineBreaks(string $content, ?string $lineBreakOption): string
+    {
+        $getLineBreaks = function (?string $configValue): string {
+            switch ($configValue ?? 'LF') {
+                case 'CR':
+                    return "\r";
+                case 'CRLF':
+                    return "\r\n";
+                case 'LF':
+                default:
+                    return "\n";
+            }
+        };
+
+        return preg_replace(
+            sprintf('/%s/m', PHP_EOL),
+            $getLineBreaks($lineBreakOption),
+            $content
+        );
+    }
+}

--- a/src/Services/Helper/TemplateLocationHelper.php
+++ b/src/Services/Helper/TemplateLocationHelper.php
@@ -5,6 +5,7 @@ namespace Linkorb\MultiRepo\Services\Helper;
 use Linkorb\MultiRepo\Services\Io\IoInterface;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Twig\Environment;
 use UnexpectedValueException;
 
 final class TemplateLocationHelper
@@ -14,12 +15,15 @@ final class TemplateLocationHelper
 
     private IoInterface $io;
 
+    private Environment $twig;
+
     private HttpClientInterface $client;
 
-    public function __construct(IoInterface $io, HttpClientInterface $client)
+    public function __construct(IoInterface $io, HttpClientInterface $client, Environment $twig)
     {
         $this->io = $io;
         $this->client = $client;
+        $this->twig = $twig;
     }
 
     public function getYamlTemplate(string $dsn): array
@@ -36,6 +40,36 @@ final class TemplateLocationHelper
                 return $this->client->request('GET', $dsn)->getContent();
             default:
                 throw new UnexpectedValueException();
+        }
+    }
+
+    public function putIfMissingFromLocation(
+        ?string $templateLocation,
+        array $filePathComponents,
+        array $renderContext = []
+    ): void
+    {
+        $fileName = end($filePathComponents);
+        $fileDirComponents = array_slice($filePathComponents, 0, -1);
+
+        if ($templateLocation && !file_exists(implode(DIRECTORY_SEPARATOR, $filePathComponents))) {
+            $this->io->write(
+                implode(DIRECTORY_SEPARATOR, $fileDirComponents),
+                $fileName,
+                $this->twig
+                    ->createTemplate($this->getTemplate($templateLocation))
+                    ->render($renderContext)
+            );
+        }
+    }
+
+    public function putIfMissingFromString(string $content, array $filePathComponents): void
+    {
+        $fileName = end($filePathComponents);
+        $fileDirComponents = array_slice($filePathComponents, 0, -1);
+
+        if (!file_exists(implode(DIRECTORY_SEPARATOR, $filePathComponents))) {
+            $this->io->write(implode(DIRECTORY_SEPARATOR, $fileDirComponents), $fileName, $content);
         }
     }
 

--- a/src/Services/Io/FindByAwareTrait.php
+++ b/src/Services/Io/FindByAwareTrait.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Linkorb\MultiRepo\Services\Io;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RecursiveRegexIterator;
+use RegexIterator;
+
+trait FindByAwareTrait
+{
+    public function findBy(string $pattern, string $directory = './'): RegexIterator
+    {
+        return new RegexIterator(
+            new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($directory)
+            ),
+            $pattern,
+            RecursiveRegexIterator::GET_MATCH
+        );
+    }
+}

--- a/src/Services/Io/IoInterface.php
+++ b/src/Services/Io/IoInterface.php
@@ -14,5 +14,5 @@ interface IoInterface
 
     public function write(string $dir, string $file, string $content): self;
 
-    public function findBy(string $pattern): iterable;
+    public function findBy(string $pattern, string $directory = './'): iterable;
 }

--- a/src/Services/Io/IoInterface.php
+++ b/src/Services/Io/IoInterface.php
@@ -13,4 +13,6 @@ interface IoInterface
     public function read(string $path): string;
 
     public function write(string $dir, string $file, string $content): self;
+
+    public function findBy(string $pattern): iterable;
 }

--- a/src/Services/Io/UnixIo.php
+++ b/src/Services/Io/UnixIo.php
@@ -7,6 +7,8 @@ use Exception;
 // TODO: Implement UnifiedIo which will use php functions for dir operations
 class UnixIo implements IoInterface
 {
+    use FindByAwareTrait;
+
     public function copyDir(string $origin, string $target): self
     {
         $this->handleUnixCommandResult(`cp -a {$origin} {$target}`);


### PR DESCRIPTION
Please pay attention to yaml fixer. There is inconsistency: reading is done by Symfony package, but writing handled by php pecl packeage. That's because php package is complaining on some Symfony yaml configs (unescaped `::` which you might see in routing files as an example), but at the same time `Yaml::dump` from Symfony is doing really poor with nested yaml levels..